### PR TITLE
Change handle-request implementations to be consistent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
   [[lein-cloverage "1.1.0"]]
 
   :dependencies
-  [[org.clojure/clojure "1.10.1"]]
+  [[amperity/vault-clj "0.7.0"]
+   [org.clojure/clojure "1.10.1"]]
 
   :java-source-paths ["src"]
 
@@ -20,8 +21,7 @@
   :profiles
   {:provided
    {:dependencies
-    [[amperity/vault-clj "0.7.0"]
-     [cd.go.plugin/go-plugin-api "19.7.0"]
+    [[cd.go.plugin/go-plugin-api "19.7.0"]
      [com.google.code.gson/gson "2.8.5"]
      [com.google.guava/guava "23.0"]]}
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
   :profiles
   {:provided
    {:dependencies
-    [[cd.go.plugin/go-plugin-api "19.7.0"]
+    [[amperity/vault-clj "0.7.0"]
+     [cd.go.plugin/go-plugin-api "19.7.0"]
      [com.google.code.gson/gson "2.8.5"]
      [com.google.guava/guava "23.0"]]}
 

--- a/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
+++ b/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
@@ -21,7 +21,7 @@ public class VaultSecretsPlugin implements GoPlugin {
 
     private GoApplicationAccessor accessor;  // Set of JSON API's exposing GoCD info specifically curated for plugins.
     private IFn handler;  // Exposes plugin API
-    private IFn client;  // The Vault Client, TODO: IMPLEMENT, currently in inconsistent state as an atom
+    private Object client;  // The Vault Client
 
 
     /**
@@ -55,7 +55,7 @@ public class VaultSecretsPlugin implements GoPlugin {
         try {
             IFn init = Clojure.var("amperity.gocd.secret.vault.plugin", "initialize!");
             IFn logger = getLoggerFn();
-            this.client = (IFn) init.invoke(logger, this.accessor);
+            this.client = init.invoke(logger, this.accessor);
         } catch (Exception ex) {
             LOGGER.error("Failed to initialize plugin state", ex);
             throw ex;

--- a/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
+++ b/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
@@ -1,7 +1,6 @@
 package amperity.gocd.secret.vault;
 
 import clojure.java.api.Clojure;
-import clojure.lang.Atom;
 import clojure.lang.IFn;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
@@ -22,7 +21,7 @@ public class VaultSecretsPlugin implements GoPlugin {
 
     private GoApplicationAccessor accessor;  // Set of JSON API's exposing GoCD info specifically curated for plugins.
     private IFn handler;  // Exposes plugin API
-    private Atom state;
+    private IFn client;  // The Vault Client, TODO: IMPLEMENT, currently in inconsistent state as an atom
 
 
     /**
@@ -56,7 +55,7 @@ public class VaultSecretsPlugin implements GoPlugin {
         try {
             IFn init = Clojure.var("amperity.gocd.secret.vault.plugin", "initialize!");
             IFn logger = getLoggerFn();
-            this.state = (Atom) init.invoke(logger, this.accessor);
+            this.client = (IFn) init.invoke(logger, this.accessor);
         } catch (Exception ex) {
             LOGGER.error("Failed to initialize plugin state", ex);
             throw ex;
@@ -72,7 +71,7 @@ public class VaultSecretsPlugin implements GoPlugin {
      */
     @Override
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
-        return (GoPluginApiResponse) this.handler.invoke(this.state, request);
+        return (GoPluginApiResponse) this.handler.invoke(this.client, request);
     }
 
 

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -3,11 +3,11 @@
   (:require
     [amperity.gocd.secret.vault.logging :as log]
     [amperity.gocd.secret.vault.util :as u]
-    [vault.core :as vault]
-    [vault.client.mock]
-    [vault.client.http]
     [clojure.java.io :as io]
-    [clojure.string :as str])
+    [clojure.string :as str]
+    [vault.client.http]
+    [vault.client.mock]
+    [vault.core :as vault])
   (:import
     (com.thoughtworks.go.plugin.api
       GoApplicationAccessor
@@ -38,11 +38,10 @@
   (atom {}))
 
 
-
 ;; ## Request Handling
 
 (defmulti handle-request
-          "Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
+  "Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
           ```{
             :response-code     <int: the returned status, follows HTTP status conventions>
             :response-body     <json-coercible: the response body, will be coerced into JSON>
@@ -53,9 +52,9 @@
           - `vault-client`: vault.client, used for auth and retrieval of all the secret values
           - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
           - `data`: map, the body of the message passed from the GoCD server"
-          (fn dispatch
-            [client req-name data]
-            req-name))
+  (fn dispatch
+    [client req-name data]
+    req-name))
 
 
 (defmethod handle-request :default
@@ -82,7 +81,6 @@
       (DefaultGoPluginApiResponse/error (.getMessage ex)))))
 
 
-
 ;; ## Plugin Metadata
 
 ;; This call is expected to return the icon for the plugin, so as to make
@@ -94,7 +92,6 @@
      :response-headers {}
      :response-body    {:content_type "image/svg+xml"
                         :data         (u/b64-encode-str icon-svg)}}))
-
 
 
 ;; ## Secrets Configuration
@@ -132,7 +129,6 @@
     {:response-code    200
      :response-headers {}
      :response-body    (into [] (remove nil?) [(validate-string :vault_addr "Vault URL")])}))
-
 
 
 ;; ## Secret Usage

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -34,7 +34,7 @@
   "Set up the vault client."
   [logger app-accessor]
   (alter-var-root #'log/logger (constantly logger))
-  ;; TODO: determine what goes in the state
+  ;; TODO: actually initialize a Vault client
   (atom {}))
 
 
@@ -54,7 +54,7 @@
           - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
           - `data`: map, the body of the message passed from the GoCD server"
           (fn dispatch
-            [state req-name data]
+            [client req-name data]
             req-name))
 
 
@@ -65,12 +65,12 @@
 
 (defn handler
   "Request handling entry-point."
-  [state ^GoPluginApiRequest request]
+  [client ^GoPluginApiRequest request]
   (try
     (let [req-name (.requestName request)
           req-data (when-not (str/blank? (.requestBody request))
                      (u/json-decode-map (.requestBody request)))
-          {status :response-code body :response-body headers :response-headers} (handle-request state req-name req-data)]
+          {status :response-code body :response-body headers :response-headers} (handle-request client req-name req-data)]
       (DefaultGoPluginApiResponse. status (u/json-encode body) headers))
     (catch UnhandledRequestTypeException ex
       (throw ex))

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -42,16 +42,16 @@
 
 (defmulti handle-request
   "Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
-          ```{
-            :response-code     <int: the returned status, follows HTTP status conventions>
-            :response-body     <json-coercible: the response body, will be coerced into JSON>
-            :response-headers  <map: the response headers, follows HTTP header conventions>
-          }```
+  ```{
+    :response-code     <int: the returned status, follows HTTP status conventions>
+    :response-body     <json-coercible: the response body, will be coerced into JSON>
+    :response-headers  <map: the response headers, follows HTTP header conventions>
+  }```
 
-          Params:
-          - `vault-client`: vault.client, used for auth and retrieval of all the secret values
-          - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
-          - `data`: map, the body of the message passed from the GoCD server"
+  Params:
+  - `client`: vault.client, used for auth and retrieval of all the secret values
+  - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
+  - `data`: map, the body of the message passed from the GoCD server"
   (fn dispatch
     [client req-name data]
     req-name))

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -26,7 +26,6 @@
 ;; ## Plugin Initialization
 
 (defn initialize!
-  ;; should really just be named initialize, not initialize!, all mutation is self contained
   ; 1. Access app info using app accessor to determine url, app-id, etc.
   ; 2. Create a vault client
   ; 3. Authenticate the vault client
@@ -35,16 +34,18 @@
   [logger app-accessor]
   (alter-var-root #'log/logger (constantly logger))
   ;; TODO: actually initialize a Vault client
-  (atom {}))
+  nil)
 
 
 ;; ## Request Handling
 
 (defmulti handle-request
   "Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
-  ```{:response-code     <int: the returned status, follows HTTP status conventions>
-      :response-body     <json-coercible: the response body, will be coerced into JSON>
-      :response-headers  <map: the response headers, follows HTTP header conventions>}```
+  ```
+  {:response-code     <int: the returned status, follows HTTP status conventions>
+   :response-body     <json-coercible: the response body, will be coerced into JSON>
+   :response-headers  <map: the response headers, follows HTTP header conventions>}
+  ```
 
   Params:
   - `client`: vault.client, used for auth and retrieval of all the secret values

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -42,11 +42,9 @@
 
 (defmulti handle-request
   "Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
-  ```{
-    :response-code     <int: the returned status, follows HTTP status conventions>
-    :response-body     <json-coercible: the response body, will be coerced into JSON>
-    :response-headers  <map: the response headers, follows HTTP header conventions>
-  }```
+  ```{:response-code     <int: the returned status, follows HTTP status conventions>
+      :response-body     <json-coercible: the response body, will be coerced into JSON>
+      :response-headers  <map: the response headers, follows HTTP header conventions>}```
 
   Params:
   - `client`: vault.client, used for auth and retrieval of all the secret values

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -1,7 +1,10 @@
 (ns amperity.gocd.secret.vault.plugin-api
   (:require
     [amperity.gocd.secret.vault.plugin :as plugin]
-    [clojure.test :refer [testing deftest is]])
+    [clojure.test :refer [testing deftest is]]
+    [vault.client.mock]
+    [vault.core :as vault]
+    [amperity.gocd.secret.vault.util :as u])
   (:import
     (com.thoughtworks.go.plugin.api.request
       DefaultGoPluginApiRequest)
@@ -28,39 +31,52 @@
   - `response1`: .GoPluginApiResponse to compare to response2
   - `response2`: .GoPluginApiResponse to compare to response1"
   [response1 response2]
+  ;; Uncomment these print statements for debugging
+  ;(println (u/json-encode response1))
+  ;(println (u/json-encode response2))
   (and (= (.responseCode response1) (.responseCode response2))
        (= (.responseBody response1) (.responseBody response2))
        (= (.responseHeaders response1) (.responseHeaders response2))))
 
 
+(defn mock-client
+  "A mock vault client using the secrets found in `resources/secret-fixture.edn`"
+  []
+  (vault/new-client "mock:resources/secret-fixture.edn"))
+
 ;; Common Logic Tests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Handler Tests
 (deftest handler-with-nil-response
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
-    (with-redefs [plugin/handle-request (fn [_ _ _] true)]
-      (is (response-equal (DefaultGoPluginApiResponse/success "")
-                          (plugin/handler (atom {}) (default-go-plugin-api-request nil)))))))
+    (with-redefs [plugin/handle-request (fn [_ _ _] {:response-code 200 :response-body "" :response-headers {}})]
+      (is (response-equal (DefaultGoPluginApiResponse/success "\"\"")
+                          (plugin/handler (mock-client) (default-go-plugin-api-request nil)))))))
 
 
 (deftest handler-with-plugin-response
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
-    (let [response (DefaultGoPluginApiResponse. 200 "response body")]
-      (with-redefs [plugin/handle-request (fn [_ _ _] response)]
-        (is (= response
-               (plugin/handler (atom {}) (default-go-plugin-api-request nil))))))))
+    (let [response (DefaultGoPluginApiResponse/success "response body")]
+      (with-redefs [plugin/handle-request
+                    (fn [_ _ _] {:response-code 200 :response-body {:message "hello"} :response-headers {}})]
+        (is (response-equal (DefaultGoPluginApiResponse/success "{\"message\":\"hello\"}")
+                            (plugin/handler (mock-client) (default-go-plugin-api-request nil))))))))
 
 
 (deftest handler-with-json-response
   (testing "Handler when handle-method returns a json response"
-    (let [response {:try "this"}]
+    (let [response {:response-code 200 :response-headers {} :response-body {:try "this"}}]
       (with-redefs [plugin/handle-request (fn [_ _ _] response)]
         (is (response-equal (DefaultGoPluginApiResponse/success "{\"try\":\"this\"}")
-                            (plugin/handler (atom {}) (default-go-plugin-api-request nil))))))))
+                            (plugin/handler (mock-client) (default-go-plugin-api-request nil))))))))
 
 ;; Endpoint Tests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (deftest get-icon
   (testing "Get icon endpoint with well formed requests"
-    (let [result-empty-body (plugin/handle-request (atom {}) "cd.go.secrets.get-icon" "")]
+    (let [result (plugin/handle-request (mock-client) "cd.go.secrets.get-icon" "")
+          body (:response-body result)
+          status (:response-code result)
+          _ (:response-headers result)]
       (is "image/svg+xml"
-          (:content_type result-empty-body))
-      (is (:data result-empty-body)))))
+          (:content_type body))
+      (is (:data body))
+      (is (= status 200)))))

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -1,10 +1,10 @@
 (ns amperity.gocd.secret.vault.plugin-api
   (:require
     [amperity.gocd.secret.vault.plugin :as plugin]
+    [amperity.gocd.secret.vault.util :as u]
     [clojure.test :refer [testing deftest is]]
     [vault.client.mock]
-    [vault.core :as vault]
-    [amperity.gocd.secret.vault.util :as u])
+    [vault.core :as vault])
   (:import
     (com.thoughtworks.go.plugin.api.request
       DefaultGoPluginApiRequest)

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -55,11 +55,10 @@
 
 (deftest handler-with-plugin-response
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
-    (let [response (DefaultGoPluginApiResponse/success "response body")]
-      (with-redefs [plugin/handle-request
-                    (fn [_ _ _] {:response-code 200 :response-body {:message "hello"} :response-headers {}})]
-        (is (response-equal (DefaultGoPluginApiResponse/success "{\"message\":\"hello\"}")
-                            (plugin/handler (mock-client) (default-go-plugin-api-request nil))))))))
+    (with-redefs [plugin/handle-request
+                  (fn [_ _ _] {:response-code 200 :response-body {:message "hello"} :response-headers {}})]
+      (is (response-equal (DefaultGoPluginApiResponse/success "{\"message\":\"hello\"}")
+                          (plugin/handler (mock-client) (default-go-plugin-api-request nil)))))))
 
 
 (deftest handler-with-json-response


### PR DESCRIPTION
While writing tests/implementing secret lookup, I noticed how the `handle-request` method implementations had different return types. This complicated tests (and the code for `handler`) and also made it harder to implement/verify endpoints against the [secret plugin API docs](https://plugin-api.gocd.org/current/secrets/#secrets-plugins).

This PR addresses that problem by being much more explicit about the expected return type in the `handle-request` implementations.

Here's the new docstring for the method:
Handle a plugin API request and respond. Methods should return a map containing the following 3 keys:
```
{:response-code     <int: the returned status, follows HTTP status conventions>
 :response-body     <json-coercible: the response body, will be coerced into JSON>
 :response-headers  <map: the response headers, follows HTTP header conventions>}
```
Params:
          - `vault-client`: vault.client, used for auth and retrieval of all the secret values
          - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
          - `data`: map, the body of the message passed from the GoCD server

All current endpoints and tests are also refactored in this PR as well to use this data structure.