### PR TITLE
Input Validation and Vault Auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ $(plugin_path): $(uberjar_path)
 	cd target/plugin; jar xf ../../$(uberjar_path)
 	find target/plugin -type f -path 'target/plugin/clojure/repl*' -delete
 	find target/plugin -type d -empty -delete
-	cd target/plugin; jar cmf META-INF/MANIFEST.MF $(plugin_name) plugin.xml amperity vault clojure com cheshire org clj_http
-
+	cd target/plugin; jar cmf META-INF/MANIFEST.MF $(plugin_name) plugin.xml amperity cheshire clj_http clojure com org potemkin riddley slingshot vault *.class *.clj *.java *.xml
 plugin: $(plugin_path)
 
 $(install_path): $(plugin_path)

--- a/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
+++ b/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
@@ -1,6 +1,7 @@
 package amperity.gocd.secret.vault;
 
 import clojure.java.api.Clojure;
+import clojure.lang.Atom;
 import clojure.lang.IFn;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
@@ -21,7 +22,7 @@ public class VaultSecretsPlugin implements GoPlugin {
 
     private GoApplicationAccessor accessor;  // Set of JSON API's exposing GoCD info specifically curated for plugins.
     private IFn handler;  // Exposes plugin API
-    private Object client;  // The Vault Client
+    private Atom client;  // The Vault Client
 
 
     /**
@@ -55,7 +56,7 @@ public class VaultSecretsPlugin implements GoPlugin {
         try {
             IFn init = Clojure.var("amperity.gocd.secret.vault.plugin", "initialize!");
             IFn logger = getLoggerFn();
-            this.client = init.invoke(logger, this.accessor);
+            this.client = (Atom) init.invoke(logger, this.accessor);
         } catch (Exception ex) {
             LOGGER.error("Failed to initialize plugin state", ex);
             throw ex;

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -37,9 +37,15 @@
 
 ;; A map of user configurable fields to the all the data necessary to define those fields
 (def input-schema
-  {:vault_addr {:metadata       {:required true :secure false}
+  {;; the name of the corresponding input field
+   :vault_addr {;; the metadata required by the plugin API about every input field
+                :metadata       {:required true :secure false}
+                ;; the string representation of the URL
                 :label          "Vault URL"
-                :validate-funcs [{:func  #(or (str/starts-with? % "http://") (str/starts-with? % "https://"))
+                ;; an array outlining extended validation the function may require
+                :validate-funcs [{;; true if valid, false if not
+                                  :func  #(or (str/starts-with? % "http://") (str/starts-with? % "https://"))
+                                  ;; the error message to be shown to the user when this pred is false
                                   :message "Vault URL must start with http:// or https://"}]}
    :auth_method {:metadata      {:required true :secure false}
                  :label         "Authentication Method"
@@ -122,7 +128,6 @@
 ;; configuring a secret backend in GoCD.
 (defmethod handle-request "go.cd.secrets.get-metadata"
   [_ _ _]
-  ;; TODO: how does the plugin authenticate?
   {:response-code    200
    :response-headers {}
    :response-body    (mapv (fn [input-key]

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -102,7 +102,7 @@
 
 ;; This call is expected to return the icon for the plugin, so as to make
 ;; it easy for users to identify the plugin.
-(defmethod handle-request "cd.go.secrets.get-icon"
+(defmethod handle-request "go.cd.secrets.get-icon"
   [_ _ _]
   (let [icon-svg (slurp (io/resource "amperity/gocd/secret/vault/logo.svg"))]
     {:response-code    200
@@ -115,7 +115,7 @@
 
 ;; This message should return an HTML template allowing users to configure the
 ;; secret backend in GoCD.
-(defmethod handle-request "go.cd.secrets.get-view"
+(defmethod handle-request "go.cd.secrets.secrets-config.get-view"
   [_ _ _]
   (let [view-html (slurp (io/resource "amperity/gocd/secret/vault/secrets-view.html"))]
     {:response-code    200
@@ -125,7 +125,7 @@
 
 ;; This message should return metadata about the available settings for
 ;; configuring a secret backend in GoCD.
-(defmethod handle-request "go.cd.secrets.get-metadata"
+(defmethod handle-request "go.cd.secrets.secrets-config.get-metadata"
   [_ _ _]
   {:response-code    200
    :response-headers {}
@@ -140,8 +140,7 @@
 
   Params:
   - `field-key`: the input field you are validating
-  - `field-value`: the inputted value which you wish to verify
-  - `field-label`: the human readable representation of the field key"
+  - `field-value`: the inputted value which you wish to verify"
   [field-key field-value]
   (let [field-model (field-key input-schema)
         validate-func-errors (remove #((:func %)  field-value)
@@ -160,7 +159,7 @@
 
 
 (defn- authenticate-client-from-inputs!
-  "Authenticates the Vault Client
+  "Authenticates the Vault Client.
 
   Params:
   - `client` The Vault Client you wish to authenticate

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -125,8 +125,9 @@
   ;; TODO: how does the plugin authenticate?
   {:response-code    200
    :response-headers {}
-   :response-body    (mapv (fn [input-key] {:key      input-key
-                                            :metadata (-> input-schema input-key :metadata)})
+   :response-body    (mapv (fn [input-key]
+                             {:key      input-key
+                              :metadata (-> input-schema input-key :metadata)})
                            (keys input-schema))})
 
 
@@ -144,7 +145,7 @@
     (cond
       ;; field is required but empty
       (and (-> field-model :metadata :required) (str/blank? field-value))
-       (str (:label field-model) " is required")
+      (str (:label field-model) " is required")
 
       ;; field is not empty and there is an error
       (not (or (str/blank? field-value) (empty? validate-func-errors)))
@@ -164,6 +165,7 @@
   (case (keyword (:auth_method inputs))
     :token
     (vault/authenticate! client :token (:vault_token inputs))))
+
 
 ;; This call is expected to validate the user inputs that form a part of
 ;; the secret backend configuration.

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -187,7 +187,7 @@
                        (= (:client-token @client) (:vault_token data)))))
       ;; Authenticate Vault client
       (try
-        (when (nil? @client)
+        (when (not (= (:api-url @client) (:vault_addr data)))
           (reset! client (vault/new-client (:vault_addr data))))
         (authenticate-client-from-inputs! @client data)
         {:response-code 200

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -35,7 +35,7 @@
   [logger app-accessor]
   (alter-var-root #'log/logger (constantly logger))
   ;; TODO: actually initialize a Vault client
-  nil)
+  (atom nil))
 
 
 ;; ## Request Handling
@@ -49,7 +49,7 @@
   ```
 
   Params:
-  - `client`: vault.client, used for auth and retrieval of all the secret values
+  - `client`: Atom(vault.client), used for auth and retrieval of all the secret values
   - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
   - `data`: map, the body of the message passed from the GoCD server"
   (fn dispatch
@@ -143,7 +143,7 @@
     (let [secret-keys (:keys data)
           secrets (mapv (fn [key]
                           {:key   key
-                           :value (vault/read-secret client key {:not-found nil})})
+                           :value (vault/read-secret @client key {:not-found nil})})
                         secret-keys)
           missing-keys (mapv :key (remove :value secrets))]
       (if (empty? missing-keys)

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -169,7 +169,10 @@
   [client inputs]
   (case (keyword (:auth_method inputs))
     :token
-    (vault/authenticate! client :token (:vault_token inputs))))
+    (vault/authenticate! client :token (:vault_token inputs))
+
+    (throw (ex-info "Could not recognize user inputted vault auth type"
+                    {:user-input (keyword (:auth_method inputs))}))))
 
 
 ;; This call is expected to validate the user inputs that form a part of

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -105,9 +105,10 @@
         (is (= 200 status))))
     (testing "Validate also resets the vault client if a new URL is specified, when input is valid only"
       (with-redefs [plugin/authenticate-client-from-inputs!
-                    (fn [_ i1] (is (= {:auth_method "token"
-                                       :vault_addr  "https://amperity.com"}
-                                      i1)))]
+                    (fn [_ i1]
+                      (is (= {:auth_method "token"
+                              :vault_addr  "https://amperity.com"}
+                             i1)))]
         (let [fake-client (atom nil)
               result (plugin/handle-request
                        fake-client "go.cd.secrets.validate"

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -86,7 +86,8 @@
       (let [result (plugin/handle-request
                      (mock-client-atom) "go.cd.secrets.validate"
                      {:vault_addr "https://amperity.com"
-                      :auth_method "token"})
+                      :auth_method "token"
+                      :vault_token "abc123"})
             body (:response-body result)
             status (:response-code result)]
         (is (= [] body))

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -124,7 +124,6 @@
               result (plugin/handle-request
                        fake-client "go.cd.secrets.validate"
                        {:vault_addr "https://amperity.com"})
-              body (:response-body result)
               status (:response-code result)]
           (is (= 200 status))
           (is (nil? @fake-client)))))
@@ -133,7 +132,6 @@
             result (plugin/handle-request
                      fake-client "go.cd.secrets.validate"
                      {})
-            body (:response-body result)
             status (:response-code result)]
         (is (= 200 status))
         (is (nil? @fake-client)))))
@@ -151,6 +149,17 @@
 java.lang.IllegalArgumentException: Token credential must be a string"}]
              body))
       (is (some? @fake-client)))))
+
+
+(deftest get-metadata
+  (testing "Input metadata is returned with the correctly structured response"
+    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.get-metadata" {})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= 200 status))
+      (is (not (empty? body)))
+      (is (every? :key body))
+      (is (every? #(and (contains? % :required) (contains? % :secure)) (map :metadata body))))))
 
 
 (deftest secrets-lookup

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -136,20 +136,20 @@
             status (:response-code result)]
         (is (= 200 status))
         (is (nil? @fake-client)))))
-    (testing "Validate also returns client authentication errors"
-        (let [fake-client (atom nil)
-              result (plugin/handle-request
-                       fake-client "go.cd.secrets.validate"
-                       {:vault_addr  "https://amperity.com"
-                        :auth_method "token"})
-              body (:response-body result)
-              status (:response-code result)]
-          (is (= 200 status))
-          (is (= [{:key     :auth_method
-                    :message "Unable to authenticate Vault client:
+  (testing "Validate also returns client authentication errors"
+    (let [fake-client (atom nil)
+          result (plugin/handle-request
+                   fake-client "go.cd.secrets.validate"
+                   {:vault_addr  "https://amperity.com"
+                    :auth_method "token"})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= 200 status))
+      (is (= [{:key     :auth_method
+               :message "Unable to authenticate Vault client:
 java.lang.IllegalArgumentException: Token credential must be a string"}]
-                 body))
-          (is (some? @fake-client)))))
+             body))
+      (is (some? @fake-client)))))
 
 
 (deftest secrets-lookup

--- a/test/amperity/gocd/secret/vault/plugin_api.clj
+++ b/test/amperity/gocd/secret/vault/plugin_api.clj
@@ -134,7 +134,21 @@
             body (:response-body result)
             status (:response-code result)]
         (is (= 200 status))
-        (is (nil? @fake-client))))))
+        (is (nil? @fake-client)))))
+    (testing "Validate also returns client authentication errors"
+        (let [fake-client (atom nil)
+              result (plugin/handle-request
+                       fake-client "go.cd.secrets.validate"
+                       {:vault_addr  "https://amperity.com"
+                        :auth_method "token"})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= 200 status))
+          (is (= [{:key     :auth_method
+                    :message "Unable to authenticate Vault client:
+java.lang.IllegalArgumentException: Token credential must be a string"}]
+                 body))
+          (is (some? @fake-client)))))
 
 
 (deftest secrets-lookup

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -51,6 +51,7 @@
   []
   (plugin/handler (mock-client-atom) (default-go-plugin-api-request nil)))
 
+
 (deftest handler-with-nil-response
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
     (with-redefs [plugin/handle-request (fn [_ _ _] {:response-code 200 :response-body "" :response-headers {}})]

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -159,7 +159,7 @@ java.lang.IllegalArgumentException: Token credential must be a string"}]
       (is (= 200 status))
       (is (= [{:key     :auth_method
                :message "Unable to authenticate Vault client:
-clojure.lang.ExceptionInfo: Could not recognize user inputted vault auth type {:user-input :fake-id-mclovin}"}]
+clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input :fake-id-mclovin}"}]
              body))
       (is (some? @fake-client)))))
 

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -71,7 +71,7 @@
 ;; Endpoint Tests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (deftest get-icon
   (testing "Get icon endpoint with well formed requests"
-    (let [result (plugin/handle-request (mock-client-atom) "cd.go.secrets.get-icon" "")
+    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.get-icon" "")
           body (:response-body result)
           status (:response-code result)]
       (is "image/svg+xml"
@@ -166,7 +166,7 @@ clojure.lang.ExceptionInfo: Could not recognize user inputted vault auth type {:
 
 (deftest get-metadata
   (testing "Input metadata is returned with the correctly structured response"
-    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.get-metadata" {})
+    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.secrets-config.get-metadata" {})
           body (:response-body result)
           status (:response-code result)]
       (is (= 200 status))

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -1,4 +1,4 @@
-(ns amperity.gocd.secret.vault.plugin-api
+(ns amperity.gocd.secret.vault.plugin-test
   (:require
     [amperity.gocd.secret.vault.plugin :as plugin]
     [amperity.gocd.secret.vault.util :as u]

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -148,6 +148,19 @@
                :message "Unable to authenticate Vault client:
 java.lang.IllegalArgumentException: Token credential must be a string"}]
              body))
+      (is (some? @fake-client)))
+    (let [fake-client (atom nil)
+          result (plugin/handle-request
+                   fake-client "go.cd.secrets.validate"
+                   {:vault_addr  "https://amperity.com"
+                    :auth_method "fake-id-mclovin"})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= 200 status))
+      (is (= [{:key     :auth_method
+               :message "Unable to authenticate Vault client:
+clojure.lang.ExceptionInfo: Could not recognize user inputted vault auth type {:user-input :fake-id-mclovin}"}]
+             body))
       (is (some? @fake-client)))))
 
 


### PR DESCRIPTION
This is not intended to be the final implementation (right now, only tokens are supported, which is helpful for our and user testing). Other validation methods will be added in a later PR.

## `go.cd.secrets.validate` Endpoint
- Authentication is done during input validation
- Client is now an `Atom`, that during initialization is set to `nil`
- Input is validated based off of an `input-schema`

## `go.cd.secrets.metadata` Endpoint
- Now reads directly from the same `input-schema` as validation, to ensure consistency