### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,6 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
-...
+## [0.1.0] - 2019-10-22
+- Initial plugin release
+- Supports one Auth Method, direct Vault tokens

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ gocd-vault-secrets
 A plugin for [GoCD](https://www.gocd.org/) providing secret material support via
 [HashiCorp Vault](https://www.vaultproject.io/).
 
-There is not yet a stable release of this plugin.
+This plugin has not yet reached `v1`, but feel free to download a `v0` release (see the installation guide below).
+
 
 <br/>
 

--- a/gocd/docker-compose.yml
+++ b/gocd/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   server:
-    image: gocd/gocd-server:v19.7.0
+    image: gocd/gocd-server:v19.9.0
     restart: on-failure
     volumes:
       - ./home:/home/go:rw
@@ -11,7 +11,7 @@ services:
       - "8154:8154"
 
   agent:
-    image: gocd/gocd-agent-ubuntu-16.04:v19.7.0
+    image: gocd/gocd-agent-ubuntu-16.04:v19.9.0
     restart: on-failure
     volumes:
       - ./home:/home/go:rw

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-vault-secrets "0.1.0-SNAPSHOT"
+(defproject amperity/gocd-vault-secrets "0.1.0"
   :description "A plugin for GoCD providing secret material support via HashiCorp Vault."
   :url "https://github.com/amperity/gocd-vault-secrets"
   :license {:name "Apache License 2.0"

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="amperity.gocd.secret.vault" version="1">
   <about>
     <name>Vault Secrets</name>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <target-go-version>19.7.0</target-go-version>
     <description>Secret material resolution via HashiCorp Vault</description>
 

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -9,18 +9,12 @@
     [vault.core :as vault])
   (:import
     clojure.lang.ExceptionInfo
-    (com.thoughtworks.go.plugin.api
-      GoApplicationAccessor
-      GoPluginIdentifier)
     (com.thoughtworks.go.plugin.api.exceptions
       UnhandledRequestTypeException)
     (com.thoughtworks.go.plugin.api.request
-      DefaultGoApiRequest
       GoPluginApiRequest)
     (com.thoughtworks.go.plugin.api.response
-      DefaultGoPluginApiResponse
-      GoPluginApiResponse)
-    java.time.Instant))
+      DefaultGoPluginApiResponse)))
 
 
 ;; ## Plugin Initialization

--- a/src/amperity/gocd/secret/vault/util.clj
+++ b/src/amperity/gocd/secret/vault/util.clj
@@ -2,7 +2,6 @@
   "Plugin utilities."
   (:require
     [clojure.java.io :as io]
-    [clojure.string :as str]
     [clojure.walk :as walk]
     [clojure.xml :as xml])
   (:import


### PR DESCRIPTION
- Version bump to `0.1.0`
- Updated Changelog
- Upgraded versions of GoCD used in testing
- Cleaned up imports