### PR TITLE
Vault Client gets Re-initialized during Secret Lookup After Server Restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 ## Unreleased
 
 - Added AWS Auth method
+- Fixed bug where secret lookup would fail after server restart
 
 ## [0.1.0] - 2019-10-22
 - Initial plugin release

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(plugin_path): $(uberjar_path)
 	cd target/plugin; jar xf ../../$(uberjar_path)
 	find target/plugin -type f -path 'target/plugin/clojure/repl*' -delete
 	find target/plugin -type d -empty -delete
-	cd target/plugin; jar cmf META-INF/MANIFEST.MF $(plugin_name) plugin.xml amperity cheshire clj_http clojure com org potemkin riddley slingshot vault *.class *.clj *.java *.xml
+	cd target/plugin; jar cmf META-INF/MANIFEST.MF $(plugin_name) plugin.xml amperity cheshire clj_http clojure com environ envoy org potemkin riddley slingshot vault *.class *.clj *.java *.xml
 plugin: $(plugin_path)
 
 $(install_path): $(plugin_path)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ If you have not completed all the above steps, go back and finish those before c
 1. First, ensure the plugin loaded successfully by checking http://localhost:8153/go/admin/plugins.
 
 2. Then, add a new secret config at http://localhost:8153/go/admin/secret_configs.
+    - You will probably be running GoCD locally in a docker container and a Vault docker container. If this is the case, make sure that you set the
+    Vault URL configuration option in GoCD to `http://host.docker.internal:<PORT>` where `<PORT>` is the port exposing your running Vault dev server.
+    You can find it at the top of your `vault -dev` server logs.
 	- You will probably be using the *token* authentication method for local dev.
 	If this is the case, copy the root `Vault Token` from your running Vault dev server. You can find it at the top of your dev server logs or by copying the id found from running `vault token lookup`.
 	**Note**: Using *token* as your authentication method should not be done in production. While the GoCD plugin does store a hashed version of this token, it is still not recommended for secure systems.

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -239,7 +239,7 @@
   [client _ data]
   (try
     (when-not @client
-      (authenticate-client-from-inputs! client (:configurations data)))
+      (authenticate-client-from-inputs! client (:configuration data)))
     (let [secrets (lookup-secrets @client (:keys data))
           missing-keys (mapv :key (remove :value secrets))]
       (if (empty? missing-keys)

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -216,21 +216,21 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mcl
         (is (= 200 status))
         (is (some? @client)))))
   (testing "If client is not defined and authentication fails, lookup fails cleanly"
-      (let [client (atom nil)
-            result (plugin/handle-request
-                     client
-                     "go.cd.secrets.secrets-lookup"
-                     {:configuration {}
-                      ;; The keys will likely be string in the http vault client instance,
-                      ;; but this is easier for testing.
-                      :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
-            body (:response-body result)
-            status (:response-code result)]
-        (is (= {:message "Error occurred during lookup:
+    (let [client (atom nil)
+          result (plugin/handle-request
+                   client
+                   "go.cd.secrets.secrets-lookup"
+                   {:configuration {}
+                    ;; The keys will likely be string in the http vault client instance,
+                    ;; but this is easier for testing.
+                    :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= {:message "Error occurred during lookup:
 clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
-               body))
-        (is (= 500 status))
-        (is (nil? @client))))
+             body))
+      (is (= 500 status))
+      (is (nil? @client))))
   (testing "Can look up individual keys stored in vault given a well formed request"
     (let [result (plugin/handle-request
                    (mock-client-atom)

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -124,16 +124,16 @@
              body))
       (is (= 200 status))))
   (testing "Validate also resets the vault client if a new URL is specified, when input is valid only"
-    (with-redefs [plugin/authenticate-client-from-inputs!
-                  (fn [_ inputs]
-                    (is (= {:auth_method "token"
-                            :vault_addr  "https://amperity.com"}
-                           inputs)))]
+    (with-redefs [vault.core/new-client
+                  (fn [_]
+                    (reify vault.core/Client
+                      (authenticate! [_ _ _] true)))]
       (let [fake-client (atom nil)
             result (plugin/handle-request
                      fake-client "go.cd.secrets.secrets-config.validate"
                      {:vault_addr  "https://amperity.com"
-                      :auth_method "token"})
+                      :auth_method "token"
+                      :token "defined token"})
             body (:response-body result)
             status (:response-code result)]
         (is (= 200 status))
@@ -195,6 +195,42 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mcl
 
 
 (deftest secrets-lookup
+  (testing "If client is not defined, it gets defined and results are returned as expected"
+    (with-redefs [plugin/authenticate-client-from-inputs!
+                  (fn [client _]
+                    (reset! client @(mock-client-atom)))]
+      (let [client (atom nil)
+            result (plugin/handle-request
+                     client
+                     "go.cd.secrets.secrets-lookup"
+                     {:configuration {}
+                      ;; The keys will likely be string in the http vault client instance,
+                      ;; but this is easier for testing.
+                      :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
+            body (:response-body result)
+            status (:response-code result)]
+        (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+                {:key "identities#hulk" :value "Bruce Banner"}
+                {:key "identities#wonder-woman" :value "Diana Prince"}]
+               body))
+        (is (= 200 status))
+        (is (some? @client)))))
+  (testing "If client is not defined and authentication fails, lookup fails cleanly"
+      (let [client (atom nil)
+            result (plugin/handle-request
+                     client
+                     "go.cd.secrets.secrets-lookup"
+                     {:configuration {}
+                      ;; The keys will likely be string in the http vault client instance,
+                      ;; but this is easier for testing.
+                      :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
+            body (:response-body result)
+            status (:response-code result)]
+        (is (= {:message "Error occurred during lookup:
+clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
+               body))
+        (is (= 500 status))
+        (is (nil? @client))))
   (testing "Can look up individual keys stored in vault given a well formed request"
     (let [result (plugin/handle-request
                    (mock-client-atom)


### PR DESCRIPTION
Resolves #9.
#### Vault Client Re-initialization ####
There are two main decisions that affect end users in this PR:
1. If not initialized before server restart, the Vault client will be initialized during secret lookup. This allows users to kick up a plugin instance that has invalid configuration (eg. if they manually updated the configurations in the xml, or if an update is not backwards compatible). However, this also allows users to change and validate those configurations using the UI, a much faster process than manually restarting the GoCD server a bunch of times or creating an entirely new plugin instance. 
2. Failure to initialize the Vault client during a job returns an error to the job console and server logs. This has a fast feedback loop for the end user, who can just resolve the error and re-run the job without digging through server logs.


#### Other Changes ####
- Also fixed a dependency bug introduced in #12 where not all required dependencies for AWS Auth were whitelisted in the `Makefile`
- `README` now describes how to reach a locally running Vault dev server from a GoCD instance running locally in a docker container