### PR TITLE
Token Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ Change Log
 All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-
-## Unreleased
+## [Unreleased]
 - Added Token Lookup option using POLICIES:<POLICY>,<POLICY>,...
 
 ## [0.2.0] - 2019-10-29
-
 - Added AWS Auth method
 - Fixed bug where secret lookup would fail after server restart
 
 ## [0.1.0] - 2019-10-22
 - Initial plugin release
 - Supports one Auth Method, direct Vault tokens
+
+[Unreleased]: https://github.com/amperity/gocd-vault-secrets/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/amperity/gocd-vault-secrets/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/amperity/gocd-vault-secrets/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 
 ## Unreleased
+- Added Token Lookup option using POLICIES:<POLICY>,<POLICY>,...
 
 ## [0.2.0] - 2019-10-29
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ In GoCD, you can refer to secret params like this:
 
 If this does not look familiar to you, you may want to check out the [GoCD secret management docs](https://docs.gocd.org/current/configuration/secrets_management.html).
 
-Here's how to set up a secret param using the Vault plugin:
+Here's how to set up a secret param using the Vault plugin (please note that these are whitespace and case sensitive):
+
+##### Token Generation
+```
+{{SECRET:[<ID SPECIFIED IN PART 3>][TOKEN:]}}
+```
+If you want that token to inherit specific policies, you can specify them after `TOKEN:` and seperated by commas:
+```
+{{SECRET:[<ID SPECIFIED IN PART 3>][TOKEN:<POLICY1>,<POLICY2>,<POLICY3>]}}
+```
 
 ##### KV API V1, Generic Secret Engine
 ```

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   [[lein-cloverage "1.1.0"]]
 
   :dependencies
-  [[amperity/vault-clj "0.7.0"]
+  [[amperity/vault-clj "0.7.1"]
    [amperity/vault-clj-aws "0.0.2"]
    [com.google.code.gson/gson "2.8.5"]
    [org.clojure/clojure "1.10.1"]]

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -248,11 +248,9 @@
   (map
     (fn [token-key]
       {:key token-key
-       :value (-> (vault/create-token!
-                    client
-                    {:policies (str/split (subs token-key (count signify-token-creation-str)) #",")})
-                  :auth
-                  :client-token)})
+       :value (:token (vault/create-token!
+                        client
+                        {:policies (str/split (subs token-key (count signify-token-creation-str)) #",")}))})
     token-keys))
 
 ;; This message is a request to the plugin to look up for secrets for a given

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -248,9 +248,9 @@
   (map
     (fn [token-key]
       {:key token-key
-       :value (:token (vault/create-token!
-                        client
-                        {:policies (str/split (subs token-key (count signify-token-creation-str)) #",")}))})
+       :value (:client-token (vault/create-token!
+                               client
+                               {:policies (str/split (subs token-key (count signify-token-creation-str)) #",")}))})
     token-keys))
 
 ;; This message is a request to the plugin to look up for secrets for a given

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -56,7 +56,7 @@
               :validate-fns []}})
 
 ;; Signifies a token creation instead of a secret lookup
-(def signify-token-creation-str "POLICIES:")
+(def signify-token-creation-str "TOKEN:")
 
 ;; ## Request Handling
 

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -292,10 +292,10 @@ clojure.lang.ExceptionInfo: Mock Exception {}"}
                    (mock-client-atom)
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                    :keys          ["POLICIES:"]})
+                    :keys          ["TOKEN:"]})
           body (:response-body result)
           status (:response-code result)]
-      (is (= "POLICIES:" (:key (first body))))
+      (is (= "TOKEN:" (:key (first body))))
       (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
       (is (= 200 status))))
   (testing "Can lookup token when specified with policies"
@@ -303,10 +303,10 @@ clojure.lang.ExceptionInfo: Mock Exception {}"}
                    (mock-client-atom)
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                    :keys          ["POLICIES:1,2,3"]})
+                    :keys          ["TOKEN:1,2,3"]})
           body (:response-body result)
           status (:response-code result)]
-      (is (= "POLICIES:1,2,3" (:key (first body))))
+      (is (= "TOKEN:1,2,3" (:key (first body))))
       (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
       (is (= 200 status))))
   (testing "Can look up individual keys stored in vault given a well formed request"
@@ -314,12 +314,12 @@ clojure.lang.ExceptionInfo: Mock Exception {}"}
                    (mock-client-atom)
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                    :keys          ["POLICIES:1,2" "POLICIES:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
+                    :keys          ["TOKEN:1,2" "TOKEN:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
           body (:response-body result)
           status (:response-code result)]
-      (is (= "POLICIES:1,2" (:key (first body))))
+      (is (= "TOKEN:1,2" (:key (first body))))
       (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
-      (is (= "POLICIES:" (:key (second body))))
+      (is (= "TOKEN:" (:key (second body))))
       (is (and (string? (:value (second body))) (pos-int? (count (:value (second body))))))
       (is (= [{:key "identities#batman" :value "Bruce Wayne"}
               {:key "identities#hulk" :value "Bruce Banner"}

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -292,12 +292,12 @@ clojure.lang.ExceptionInfo: Mock Exception {}"}
                    (mock-client-atom)
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                      :keys          ["POLICIES:"]})
-            body (:response-body result)
-            status (:response-code result)]
-        (is (= "POLICIES:" (:key (first body))))
-        (is (= [] (-> (first body) :auth :policies)))
-        (is (= 200 status))))
+                    :keys          ["POLICIES:"]})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= "POLICIES:" (:key (first body))))
+      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+      (is (= 200 status))))
   (testing "Can lookup token when specified with policies"
     (let [result (plugin/handle-request
                    (mock-client-atom)
@@ -307,22 +307,22 @@ clojure.lang.ExceptionInfo: Mock Exception {}"}
           body (:response-body result)
           status (:response-code result)]
       (is (= "POLICIES:1,2,3" (:key (first body))))
-      (is (= ["1" "2" "3"] (-> (first body) :auth :policies)))
+      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+      (is (= 200 status))))
+  (testing "Can look up individual keys stored in vault given a well formed request"
+    (let [result (plugin/handle-request
+                   (mock-client-atom)
+                   "go.cd.secrets.secrets-lookup"
+                   {:configuration {}
+                    :keys          ["POLICIES:1,2" "POLICIES:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= "POLICIES:1,2" (:key (first body))))
+      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+      (is (= "POLICIES:" (:key (second body))))
+      (is (and (string? (:value (second body))) (pos-int? (count (:value (second body))))))
+      (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+              {:key "identities#hulk" :value "Bruce Banner"}
+              {:key "identities#wonder-woman" :value "Diana Prince"}]
+             (subvec body 2)))
       (is (= 200 status)))))
-(testing "Can look up individual keys stored in vault given a well formed request"
-  (let [result (plugin/handle-request
-                 (mock-client-atom)
-                 "go.cd.secrets.secrets-lookup"
-                 {:configuration {}
-                  :keys          ["POLICIES:1,2" "POLICIES:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
-        body (:response-body result)
-        status (:response-code result)]
-    (is (= "POLICIES:1,2" (:key (first body))))
-    (is (= ["1" "2"] (-> (first body) :auth :policies)))
-    (is (= "POLICIES:" (:key (second body))))
-    (is (= [] (-> (second body) :auth :policies)))
-    (is (= [{:key "identities#batman" :value "Bruce Wayne"}
-            {:key "identities#hulk" :value "Bruce Banner"}
-            {:key "identities#wonder-woman" :value "Diana Prince"}]
-           (subvec body 2)))
-    (is (= 200 status))))

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -228,8 +228,6 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mcl
                      client
                      "go.cd.secrets.secrets-lookup"
                      {:configuration {}
-                      ;; The keys will likely be string in the http vault client instance,
-                      ;; but this is easier for testing.
                       :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
             body (:response-body result)
             status (:response-code result)]
@@ -245,8 +243,6 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mcl
                    client
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                    ;; The keys will likely be string in the http vault client instance,
-                    ;; but this is easier for testing.
                     :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
           body (:response-body result)
           status (:response-code result)]
@@ -260,8 +256,6 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
                    (mock-client-atom)
                    "go.cd.secrets.secrets-lookup"
                    {:configuration {}
-                    ;; The keys will likely be string in the http vault client instance,
-                    ;; but this is easier for testing.
                     :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
           body (:response-body result)
           status (:response-code result)]
@@ -292,4 +286,43 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
       (is (= {:message "Error occurred during lookup of: [\"identities#batman\"]
 clojure.lang.ExceptionInfo: Mock Exception {}"}
              body))
-      (is (= 500 status)))))
+      (is (= 500 status))))
+  (testing "Can lookup token when specified without policies"
+    (let [result (plugin/handle-request
+                   (mock-client-atom)
+                   "go.cd.secrets.secrets-lookup"
+                   {:configuration {}
+                      :keys          ["POLICIES:"]})
+            body (:response-body result)
+            status (:response-code result)]
+        (is (= "POLICIES:" (:key (first body))))
+        (is (= [] (-> (first body) :auth :policies)))
+        (is (= 200 status))))
+  (testing "Can lookup token when specified with policies"
+    (let [result (plugin/handle-request
+                   (mock-client-atom)
+                   "go.cd.secrets.secrets-lookup"
+                   {:configuration {}
+                    :keys          ["POLICIES:1,2,3"]})
+          body (:response-body result)
+          status (:response-code result)]
+      (is (= "POLICIES:1,2,3" (:key (first body))))
+      (is (= ["1" "2" "3"] (-> (first body) :auth :policies)))
+      (is (= 200 status)))))
+(testing "Can look up individual keys stored in vault given a well formed request"
+  (let [result (plugin/handle-request
+                 (mock-client-atom)
+                 "go.cd.secrets.secrets-lookup"
+                 {:configuration {}
+                  :keys          ["POLICIES:1,2" "POLICIES:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
+        body (:response-body result)
+        status (:response-code result)]
+    (is (= "POLICIES:1,2" (:key (first body))))
+    (is (= ["1" "2"] (-> (first body) :auth :policies)))
+    (is (= "POLICIES:" (:key (second body))))
+    (is (= [] (-> (second body) :auth :policies)))
+    (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+            {:key "identities#hulk" :value "Bruce Banner"}
+            {:key "identities#wonder-woman" :value "Diana Prince"}]
+           (subvec body 2)))
+    (is (= 200 status))))


### PR DESCRIPTION
Resolves #23 

Updated:
Ended up deciding on:
```
TOKEN:
```
for a token with access to all the same policies as the GoCD Vault Instance, and
```
TOKEN:<POLICY1>,<POLICY2>,<POLICY3>
```
to specify specific policies.

That makes the whole lookup:
```
{{SECRET:[<VAULT PLUGIN INSTANCE>][TOKEN:]}}
```
and
```
{{SECRET:[<VAULT PLUGIN INSTANCE>][TOKEN:<POLICY1>,<POLICY2>,<POLICY3>]}}
```
respectively.

This syntax is super simple to change, so let me know if you have a preferred syntax


TODOs before merge:
- [x] Update `vault-clj` version after issue is resolved
- [x] Update `README`
