### PR TITLE
Force-read Secrets in Lookup, `0.3.1` Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,28 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 ## [Unreleased]
 ...
 
+## [0.3.1] - 2019-11-22
+- Added an option to ignore TTLs specified in Vault and force-read secrets
+  [#26](https://github.com/amperity/gocd-vault-secrets/issues/26)
+
 ## [0.3.0] - 2019-11-20
-- Added Token Lookup option using TOKENS:<POLICY>,<POLICY>,...
+- Added Token Lookup option using `TOKENS:<POLICY>,<POLICY>,...`
+  [#23](https://github.com/amperity/gocd-vault-secrets/issues/23)
 
 ## [0.2.0] - 2019-10-29
 - Added AWS Auth method
+  [#12](https://github.com/amperity/gocd-vault-secrets/pull/12)
 - Fixed bug where secret lookup would fail after server restart
+  [#9](https://github.com/amperity/gocd-vault-secrets/issues/9)
 
 ## [0.1.0] - 2019-10-22
 - Initial plugin release
+  [#0](https://media.giphy.com/media/o0eOCNkn7cSD6/giphy.gif)
 - Supports one Auth Method, direct Vault tokens
+  [#4](https://github.com/amperity/gocd-vault-secrets/pull/4)
 
-[Unreleased]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/amperity/gocd-vault-secrets/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/amperity/gocd-vault-secrets/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/amperity/gocd-vault-secrets/releases/tag/v0.1.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-vault-secrets "0.3.1-SNAPSHOT"
+(defproject amperity/gocd-vault-secrets "0.3.1"
   :description "A plugin for GoCD providing secret material support via HashiCorp Vault."
   :url "https://github.com/amperity/gocd-vault-secrets"
   :license {:name "Apache License 2.0"

--- a/resources/amperity/gocd/secret/vault/secrets-view.html
+++ b/resources/amperity/gocd/secret/vault/secrets-view.html
@@ -31,4 +31,15 @@
         <input type="text" ng-model="iam_role" ng-required="false" placeholder=""/>
         <span class="iam_role" ng-show="GOINPUTNAME[iam_role].$error.server">{{GOINPUTNAME[iam_role].$error.server}}</span>
     </div>
+
+    <div class="form_item_block">
+        <label>Secret Caching</label>
+        <form>
+            <select ng-model="force_read" ng-required="true">
+                <option value="false">Cache secrets according to their TTLs stored in Vault</option>
+                <option value="true">Ignore cached secrets and always query Vault</option>
+            </select>
+        </form>
+        <span class="form_error" ng-show="GOINPUTNAME[force_read].$error.server">{{GOINPUTNAME[force_read].$error.server}}</span>
+    </div>
 </fieldset>

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="amperity.gocd.secret.vault" version="1">
   <about>
     <name>Vault Secrets</name>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.1</version>
     <target-go-version>19.7.0</target-go-version>
     <description>Secret material resolution via HashiCorp Vault</description>
 

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -45,7 +45,7 @@
    :auth_method {:metadata     {:required true :secure false}
                  :label        "Authentication Method"
                  :validate-fns []}
-   :force_read  {:metadata     {:required false :secure false}
+   :force_read  {:metadata     {:required true :secure false}
                  :label         "Force Read (Secret Caching)"
                  :validate-fns []}
    ;; Token Auth
@@ -269,7 +269,7 @@
     (when-not @client
       (authenticate-client-from-inputs! client (:configuration data)))
     (let [{token-keys true secrets-keys false} (group-by #(str/starts-with?  % signify-token-creation-str) (:keys data))
-          secrets (lookup-secrets @client secrets-keys (-> data :configuration :force_read))]
+          secrets (lookup-secrets @client secrets-keys (= (-> data :configuration :force_read) "true"))]
       (if-let [missing-keys (->> secrets
                                  (remove :value)
                                  (mapv :key)

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -46,7 +46,7 @@
                  :label        "Authentication Method"
                  :validate-fns []}
    :force_read  {:metadata     {:required false :secure false}
-                 :label         "Ignore cached secrets if this is checked (ignore secret TTLs)"
+                 :label         "Force Read (Secret Caching)"
                  :validate-fns []}
    ;; Token Auth
    :vault_token {:metadata     {:required false :secure true}

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -284,7 +284,7 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
                (plugin/handle-request
                  client
                  "go.cd.secrets.secrets-lookup"
-                 {:configuration {:force_read true}
+                 {:configuration {:force_read "true"}
                   :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]}))))))
   (testing "Fails cleanly when looking up secrets that don't exist"
     (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.secrets-lookup"

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -116,7 +116,8 @@
                    (mock-client-atom) "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
                     :auth_method "token"
-                    :vault_token "abc123"})
+                    :vault_token "abc123"
+                    :force_read  "true"})
           body (:response-body result)
           status (:response-code result)]
       (is (= [] body))
@@ -130,7 +131,8 @@
                      {:vault_addr      "https://amperity.com"
                       :auth_method     "aws-iam"
                       :iam_role        "role"
-                      :aws_credentials (aws/derive-credentials "hello" "goodbye" "7")})
+                      :aws_credentials (aws/derive-credentials "hello" "goodbye" "7")
+                      :force_read "false"})
             body (:response-body result)
             status (:response-code result)]
         (is (= [] body))
@@ -138,7 +140,8 @@
   (testing "Validate correctly handles case with errors (no false negatives, no false positives)"
     (let [result (plugin/handle-request
                    (mock-client-atom) "go.cd.secrets.secrets-config.validate"
-                   {:vault_addr "protocol://amperity.com"})
+                   {:vault_addr "protocol://amperity.com"
+                    :force_read "false"})
           body (:response-body result)
           status (:response-code result)]
       (is (= [{:key     :vault_addr
@@ -157,7 +160,8 @@
                      fake-client "go.cd.secrets.secrets-config.validate"
                      {:vault_addr  "https://amperity.com"
                       :auth_method "token"
-                      :token "defined token"})
+                      :token "defined token"
+                      :force_read "false"})
             body (:response-body result)
             status (:response-code result)]
         (is (= 200 status))
@@ -183,7 +187,8 @@
           result (plugin/handle-request
                    fake-client "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
-                    :auth_method "token"})
+                    :auth_method "token"
+                    :force_read "false"})
           body (:response-body result)
           status (:response-code result)]
       (is (= 200 status))
@@ -196,7 +201,8 @@ java.lang.IllegalArgumentException: Token credential must be a string"}]
           result (plugin/handle-request
                    fake-client "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
-                    :auth_method "fake-id-mclovin"})
+                    :auth_method "fake-id-mclovin"
+                    :force_read "true"})
           body (:response-body result)
           status (:response-code result)]
       (is (= 200 status))


### PR DESCRIPTION
Resolves #26 

Checkboxes are weird so I went for a dropdown menu in the UI. Tested locally in docker and unit tests added.

## Minor version release
`0.3.1` up from `0.3.0`

## Other
Updated `CHANGELOG` to link to issues and PRs describing each change