### PR TITLE
start the vault client lease timer to correctly notice and renew leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-...
+- Fixed bug where vault lease timer didn't run so client tokens weren't renewed.
+  [#29](https://github.com/amperity/gocd-vault-secrets/pull/29)
 
 ## [0.3.1] - 2019-11-22
 - Added an option to ignore TTLs specified in Vault and force-read secrets

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -5,6 +5,7 @@
     [amperity.gocd.secret.vault.util :as u]
     [clojure.java.io :as io]
     [clojure.string :as str]
+    [com.stuartsierra.component :as component]
     [vault.client.ext.aws]
     [vault.client.http]
     [vault.core :as vault])
@@ -165,7 +166,8 @@
   - `inputs` A map containing the user inputted settings for the plugin"
   [client inputs]
   (when-not (= (:api-url @client) (:vault_addr inputs))
-    (reset! client (vault/new-client (:vault_addr inputs))))
+    (reset! client (component/start
+                     (vault/new-client (:vault_addr inputs)))))
   (case (:auth_method inputs)
     "token"
     (vault/authenticate! @client :token


### PR DESCRIPTION
This is the reason reading vault secrets stopped working after ~10 minutes when configured to authenticate with the ec2 instance profile: the lease timer was not running, so the client token was not getting renewed.

The vault client implements the component/Lifecycle protocol, so starting it is east enough.

https://github.com/amperity/vault-clj/blob/develop/src/vault/client/http.clj#L44

This has been validated via functional testing in situ:
 1. Log onto ec2 instance configured with ec2 instance profile auth to vault.
 2. Download lein.
 3. Clone the https://github.com/amperity/vault-clj-aws repo.
 4. Run lein repl in that project, authenticating with the `:aws-iam` keyword switch.
