### PR TITLE
Remove shared Vault client object from VaultSecretsPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 ## [Unreleased]
 ..
 
+## [0.3.3] - 2020-01-09
+- Fixed bug where plugin couldn't handle reading secrets from multiple configs.
+  [#31](https://github.com/amperity/gocd-vault-secrets/pull/31)
+
 ## [0.3.2] - 2019-12-06
 - Fixed bug where vault lease timer didn't run so client tokens weren't renewed.
   [#29](https://github.com/amperity/gocd-vault-secrets/pull/29)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-vault-secrets "0.3.2"
+(defproject amperity/gocd-vault-secrets "0.3.3"
   :description "A plugin for GoCD providing secret material support via HashiCorp Vault."
   :url "https://github.com/amperity/gocd-vault-secrets"
   :license {:name "Apache License 2.0"

--- a/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
+++ b/src/amperity/gocd/secret/vault/VaultSecretsPlugin.java
@@ -22,7 +22,6 @@ public class VaultSecretsPlugin implements GoPlugin {
 
     private GoApplicationAccessor accessor;  // Set of JSON API's exposing GoCD info specifically curated for plugins.
     private IFn handler;  // Exposes plugin API
-    private Atom client;  // The Vault Client
 
 
     /**
@@ -56,7 +55,7 @@ public class VaultSecretsPlugin implements GoPlugin {
         try {
             IFn init = Clojure.var("amperity.gocd.secret.vault.plugin", "initialize!");
             IFn logger = getLoggerFn();
-            this.client = (Atom) init.invoke(logger, this.accessor);
+            init.invoke(logger, this.accessor);
         } catch (Exception ex) {
             LOGGER.error("Failed to initialize plugin state", ex);
             throw ex;
@@ -72,7 +71,7 @@ public class VaultSecretsPlugin implements GoPlugin {
      */
     @Override
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
-        return (GoPluginApiResponse) this.handler.invoke(this.client, request);
+        return (GoPluginApiResponse) this.handler.invoke(request);
     }
 
 

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -26,8 +26,7 @@
 (defn initialize!
   "Set up the vault client."
   [logger app-accessor]
-  (alter-var-root #'log/logger (constantly logger))
-  (atom nil))
+  (alter-var-root #'log/logger (constantly logger)))
 
 
 ;; ## Model
@@ -77,24 +76,24 @@
   - `req-name`: string, determines how to dispatch among implementing methods, essentially the route
   - `data`: map, the body of the message passed from the GoCD server"
   (fn dispatch
-    [client req-name data]
+    [req-name data]
     ;(log/logger "info" (str "Vault plugin received: " req-name) nil)  ;; Most useful log statement for debugging
     req-name))
 
 
 (defmethod handle-request :default
-  [_ req-name _]
+  [req-name _]
   (throw (UnhandledRequestTypeException. req-name)))
 
 
 (defn handler
   "Request handling entry-point."
-  [client ^GoPluginApiRequest request]
+  [^GoPluginApiRequest request]
   (try
     (let [req-name (.requestName request)
           req-data (when-not (str/blank? (.requestBody request))
                      (u/json-decode-map (.requestBody request)))
-          {status :response-code body :response-body headers :response-headers} (handle-request client req-name req-data)]
+          {status :response-code body :response-body headers :response-headers} (handle-request req-name req-data)]
       (DefaultGoPluginApiResponse. status (u/json-encode body) headers))
     (catch UnhandledRequestTypeException ex
       (throw ex))
@@ -111,7 +110,7 @@
 ;; This call is expected to return the icon for the plugin, so as to make
 ;; it easy for users to identify the plugin.
 (defmethod handle-request "go.cd.secrets.get-icon"
-  [_ _ _]
+  [_ _]
   (let [icon-svg (slurp (io/resource "amperity/gocd/secret/vault/logo.svg"))]
     {:response-code    200
      :response-headers {}
@@ -124,7 +123,7 @@
 ;; This message should return an HTML template allowing users to configure the
 ;; secret backend in GoCD.
 (defmethod handle-request "go.cd.secrets.secrets-config.get-view"
-  [_ _ _]
+  [_ _]
   (let [view-html (slurp (io/resource "amperity/gocd/secret/vault/secrets-view.html"))]
     {:response-code    200
      :response-headers {}
@@ -134,7 +133,7 @@
 ;; This message should return metadata about the available settings for
 ;; configuring a secret backend in GoCD.
 (defmethod handle-request "go.cd.secrets.secrets-config.get-metadata"
-  [_ _ _]
+  [_ _]
   {:response-code    200
    :response-headers {}
    :response-body    (mapv (fn [input-key]
@@ -158,6 +157,12 @@
         (some #(% field-value) (:validate-fns field-model))))))
 
 
+(defn- client-from-inputs
+  [inputs]
+  (component/start
+    (vault/new-client (:vault_addr inputs))))
+
+
 (defn- authenticate-client-from-inputs!
   "Authenticates the Vault Client.
 
@@ -165,16 +170,13 @@
   - `client` An atom containing the Vault Client you wish to authenticate, may contain nil if you want a new client.
   - `inputs` A map containing the user inputted settings for the plugin"
   [client inputs]
-  (when-not (= (:api-url @client) (:vault_addr inputs))
-    (reset! client (component/start
-                     (vault/new-client (:vault_addr inputs)))))
   (case (:auth_method inputs)
     "token"
-    (vault/authenticate! @client :token
+    (vault/authenticate! client :token
                          (:vault_token inputs))
 
     "aws-iam"
-    (vault/authenticate! @client :aws-iam
+    (vault/authenticate! client :aws-iam
                          {:iam-role    (:iam_role inputs)
                           :credentials ^AWSCredentials (:aws_credentials inputs)})
 
@@ -185,29 +187,26 @@
 ;; This call is expected to validate the user inputs that form a part of
 ;; the secret backend configuration.
 (defmethod handle-request "go.cd.secrets.secrets-config.validate"
-  [client _ data]
+  [_ data]
   (let [input-error (fn [field-key]
                       (when-let [error-message (input-error-message field-key (field-key data))]
                         {:key field-key
                          :message error-message}))
         errors-found (keep input-error (keys input-schema))]
-    (if (and (empty? errors-found)
-             ;; Need to Authenticate?
-             (not (and (= (:api-url @client) (:vault_addr data))
-                       (= (:auth-type @client) (:auth_method data))
-                       (= (:client-token @client) (:vault_token data)))))
-      ;; Authenticate Vault client
-      (try
-        (authenticate-client-from-inputs! client data)
-        {:response-code 200
-         :response-headers {}
-         :response-body []}
-
-        (catch Exception ex
+    (if (empty? errors-found)
+      (let [client (client-from-inputs data)]
+        (try
+          (authenticate-client-from-inputs! client data)
           {:response-code 200
            :response-headers {}
-           :response-body [{:key :auth_method
-                            :message (str "Unable to authenticate Vault client:\n" ex)}]}))
+           :response-body []}
+          (catch Exception ex
+            {:response-code 200
+             :response-headers {}
+             :response-body [{:key :auth_method
+                              :message (str "Unable to authenticate Vault client:\n" ex)}]})
+          (finally
+            (component/stop client))))
       {:response-code    200
        :response-headers {}
        :response-body    (into [] errors-found)})))
@@ -266,25 +265,27 @@
 ;; request body will also have the configuration required to connect and lookup
 ;; for secrets from the external Secret Manager.
 (defmethod handle-request "go.cd.secrets.secrets-lookup"
-  [client _ data]
-  (try
-    (when-not @client
-      (authenticate-client-from-inputs! client (:configuration data)))
-    (let [{token-keys true secrets-keys false} (group-by #(str/starts-with?  % signify-token-creation-str) (:keys data))
-          secrets (lookup-secrets @client secrets-keys (= (-> data :configuration :force_read) "true"))]
-      (if-let [missing-keys (->> secrets
-                                 (remove :value)
-                                 (mapv :key)
-                                 not-empty)]
-        {:response-code    404
+  [_ data]
+  (let [client (client-from-inputs (:configuration data))]
+    (try
+      (authenticate-client-from-inputs! client (:configuration data))
+      (let [{token-keys true secrets-keys false} (group-by #(str/starts-with?  % signify-token-creation-str) (:keys data))
+            secrets (lookup-secrets client secrets-keys (= (-> data :configuration :force_read) "true"))]
+        (if-let [missing-keys (->> secrets
+                                   (remove :value)
+                                   (mapv :key)
+                                   not-empty)]
+          {:response-code    404
+           :response-headers {}
+           :response-body    {:message (str "Unable to resolve key(s) " missing-keys)}}
+          {:response-code    200
+           :response-headers {}
+           :response-body    (-> (create-tokens! client token-keys)
+                                 (concat secrets)
+                                 (->> (mapv #(update % :value str))))}))
+      (catch ExceptionInfo ex
+        {:response-code    500
          :response-headers {}
-         :response-body    {:message (str "Unable to resolve key(s) " missing-keys)}}
-        {:response-code    200
-         :response-headers {}
-         :response-body    (-> (create-tokens! @client token-keys)
-                               (concat secrets)
-                               (->> (mapv #(update % :value str))))}))
-    (catch ExceptionInfo ex
-      {:response-code    500
-       :response-headers {}
-       :response-body    {:message (str "Error occurred during lookup of: " (:keys data) "\n" ex)}})))
+         :response-body    {:message (str "Error occurred during lookup of: " (:keys data) "\n" ex)}})
+      (finally
+        (component/stop client)))))

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -47,10 +47,10 @@
        (= (.responseHeaders response1) (.responseHeaders response2))))
 
 
-(defn mock-client-atom
+(defn mock-client
   "A mock vault client using the secrets found in `resources/secret-fixture.edn`"
   []
-  (atom (vault/new-client "mock:amperity/gocd/secret/vault/secret-fixture.edn")))
+  (vault/new-client "mock:amperity/gocd/secret/vault/secret-fixture.edn"))
 
 
 ;; Common Logic Tests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -58,55 +58,48 @@
 (defn default-handler
   "Thunk that sends an empty request, using a a mock client"
   []
-  (plugin/handler (mock-client-atom) (default-go-plugin-api-request nil)))
+  (plugin/handler (default-go-plugin-api-request nil)))
 
 
 (deftest handler-routing-fake-endpoint
   (testing "Handler when handle-method fails to route to an endpoint correctly"
     (is (thrown-with-msg?
           UnhandledRequestTypeException #"You have chose poorly"
-          (plugin/handler (mock-client-atom) (default-go-plugin-api-request "You have chose poorly" {:totally "here"})))))
+          (plugin/handler (default-go-plugin-api-request "You have chose poorly" {:totally "here"})))))
   (testing "Handler when fails with some unknown error"
-    (with-redefs [plugin/handle-request (fn [_ _ _] (throw (ex-info "this is an error" {})))
+    (with-redefs [plugin/handle-request (fn [_ _] (throw (ex-info "this is an error" {})))
                   log/errorx (fn [_ _ _ _] nil)]
       (is (response-equal (DefaultGoPluginApiResponse/error "this is an error")
                           (default-handler)))))
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
-    (with-redefs [plugin/handle-request (fn [_ _ _] {:response-code 200 :response-body "" :response-headers {}})]
+    (with-redefs [plugin/handle-request (fn [_ _] {:response-code 200 :response-body "" :response-headers {}})]
       (is (response-equal (DefaultGoPluginApiResponse/success "\"\"")
                           (default-handler)))))
   (testing "Handler when handle-method returns a GoPluginApiResponse response"
     (with-redefs [plugin/handle-request
-                  (fn [_ _ _] {:response-code 200 :response-body {:message "hello"} :response-headers {}})]
+                  (fn [_ _] {:response-code 200 :response-body {:message "hello"} :response-headers {}})]
       (is (response-equal (DefaultGoPluginApiResponse/success "{\"message\":\"hello\"}")
                           (default-handler)))))
   (testing "Handler when handle-method returns a json response"
     (let [response {:response-code 200 :response-headers {} :response-body {:try "this"}}]
-      (with-redefs [plugin/handle-request (fn [_ _ _] response)]
+      (with-redefs [plugin/handle-request (fn [_ _] response)]
         (is (response-equal (DefaultGoPluginApiResponse/success "{\"try\":\"this\"}")
                             (default-handler))))))
   (testing "Handler when request includes a JSON body and handle-method returns a json response"
     (let [response {:response-code 200 :response-headers {} :response-body {:try "this"}}]
-      (with-redefs [plugin/handle-request (fn [_ _ _] response)]
+      (with-redefs [plugin/handle-request (fn [_ _] response)]
         (is (response-equal (DefaultGoPluginApiResponse/success "{\"try\":\"this\"}")
                             (plugin/handler
-                              (mock-client-atom)
                               (default-go-plugin-api-request "ignored" {}  (u/json-encode {:try "this"
                                                                                            :and ["a" "vec"]
                                                                                            "or" {:another "map"}
                                                                                            :maybe #{1 2 3}})))))))))
 
 
-(deftest initialize!-test
-  (testing "initialize! returns an atom for the vault client"
-    (with-redefs [alter-var-root (fn [_ _] nil)]
-      (is (nil? @(plugin/initialize! nil nil))))))
-
-
 ;; Endpoint Tests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (deftest get-icon
   (testing "Get icon endpoint with well formed requests"
-    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.get-icon" "")
+    (let [result (plugin/handle-request "go.cd.secrets.get-icon" "")
           body (:response-body result)
           status (:response-code result)]
       (is "image/svg+xml"
@@ -117,7 +110,7 @@
 
 (deftest get-view
   (testing "Get view endpoint with well formed requests"
-    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.secrets-config.get-view" "")
+    (let [result (plugin/handle-request "go.cd.secrets.secrets-config.get-view" "")
           body (:response-body result)
           status (:response-code result)]
       (is (some? (:template body)))
@@ -127,7 +120,7 @@
 (deftest validate
   (testing "Validate correctly handles case with no errors (no false positives)"
     (let [result (plugin/handle-request
-                   (mock-client-atom) "go.cd.secrets.secrets-config.validate"
+                   "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
                     :auth_method "token"
                     :vault_token "abc123"
@@ -140,7 +133,6 @@
     (with-redefs [vault.client.http/do-api-request (fn [_ _ _] true)
                   vault.client.http/api-auth! (fn [_ _ _] true)]
       (let [result (plugin/handle-request
-                     (mock-client-atom)
                      "go.cd.secrets.secrets-config.validate"
                      {:vault_addr      "https://amperity.com"
                       :auth_method     "aws-iam"
@@ -153,7 +145,7 @@
         (is (= 200 status)))))
   (testing "Validate correctly handles case with errors (no false negatives, no false positives)"
     (let [result (plugin/handle-request
-                   (mock-client-atom) "go.cd.secrets.secrets-config.validate"
+                   "go.cd.secrets.secrets-config.validate"
                    {:vault_addr "protocol://amperity.com"
                     :force_read "false"})
           body (:response-body result)
@@ -164,42 +156,9 @@
                :message "Authentication Method is required"}]
              body))
       (is (= 200 status))))
-  (testing "Validate also resets the vault client if a new URL is specified, when input is valid only"
-    (with-redefs [vault.core/new-client
-                  (fn [_]
-                    (reify vault.core/Client
-                      (authenticate! [_ _ _] true)))]
-      (let [fake-client (atom nil)
-            result (plugin/handle-request
-                     fake-client "go.cd.secrets.secrets-config.validate"
-                     {:vault_addr  "https://amperity.com"
-                      :auth_method "token"
-                      :token "defined token"
-                      :force_read "false"})
-            body (:response-body result)
-            status (:response-code result)]
-        (is (= 200 status))
-        (is (= [] body))
-        (is (some? @fake-client)))
-      (let [fake-client (atom nil)
-            result (plugin/handle-request
-                     fake-client "go.cd.secrets.secrets-config.validate"
-                     {:vault_addr "https://amperity.com"})
-            status (:response-code result)]
-        (is (= 200 status))
-        (is (nil? @fake-client)))))
-  (testing "Validate a does not reset the vault client if no new URL is specified "
-    (let [fake-client (atom nil)
-          result (plugin/handle-request
-                   fake-client "go.cd.secrets.secrets-config.validate"
-                   {})
-          status (:response-code result)]
-      (is (= 200 status))
-      (is (nil? @fake-client))))
   (testing "Validate also returns client authentication errors"
-    (let [fake-client (atom nil)
-          result (plugin/handle-request
-                   fake-client "go.cd.secrets.secrets-config.validate"
+    (let [result (plugin/handle-request
+                   "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
                     :auth_method "token"
                     :force_read "false"})
@@ -209,11 +168,9 @@
       (is (= [{:key     :auth_method
                :message "Unable to authenticate Vault client:
 java.lang.IllegalArgumentException: Token credential must be a string"}]
-             body))
-      (is (some? @fake-client)))
-    (let [fake-client (atom nil)
-          result (plugin/handle-request
-                   fake-client "go.cd.secrets.secrets-config.validate"
+             body)))
+    (let [result (plugin/handle-request
+                   "go.cd.secrets.secrets-config.validate"
                    {:vault_addr  "https://amperity.com"
                     :auth_method "fake-id-mclovin"
                     :force_read "true"})
@@ -223,13 +180,12 @@ java.lang.IllegalArgumentException: Token credential must be a string"}]
       (is (= [{:key     :auth_method
                :message "Unable to authenticate Vault client:
 clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mclovin\"}"}]
-             body))
-      (is (some? @fake-client)))))
+             body)))))
 
 
 (deftest get-metadata
   (testing "Input metadata is returned with the correctly structured response"
-    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.secrets-config.get-metadata" {})
+    (let [result (plugin/handle-request "go.cd.secrets.secrets-config.get-metadata" {})
           body (:response-body result)
           status (:response-code result)]
       (is (= 200 status))
@@ -239,132 +195,125 @@ clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input \"fake-id-mcl
 
 
 (deftest secrets-lookup
-  (testing "If client is not defined, it gets defined and results are returned as expected"
-    (with-redefs [plugin/authenticate-client-from-inputs!
-                  (fn [client _]
-                    (reset! client @(mock-client-atom)))]
-      (let [client (atom nil)
-            result (plugin/handle-request
-                     client
+  (with-redefs [plugin/client-from-inputs
+                (fn [_]
+                  (mock-client))]
+    (testing "If authentication fails, lookup fails cleanly"
+      (let [result (plugin/handle-request
                      "go.cd.secrets.secrets-lookup"
                      {:configuration {}
                       :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
             body (:response-body result)
             status (:response-code result)]
-        (is (= [{:key "identities#batman" :value "Bruce Wayne"}
-                {:key "identities#hulk" :value "Bruce Banner"}
-                {:key "identities#wonder-woman" :value "Diana Prince"}]
-               body))
-        (is (= 200 status))
-        (is (some? @client)))))
-  (testing "If client is not defined and authentication fails, lookup fails cleanly"
-    (let [client (atom nil)
-          result (plugin/handle-request
-                   client
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= {:message "Error occurred during lookup of: [\"identities#batman\" \"identities#hulk\" \"identities#wonder-woman\"]
+        (is (= {:message "Error occurred during lookup of: [\"identities#batman\" \"identities#hulk\" \"identities#wonder-woman\"]
 clojure.lang.ExceptionInfo: Unhandled vault auth type {:user-input nil}"}
-             body))
-      (is (= 500 status))
-      (is (nil? @client))))
-  (testing "Can look up individual keys stored in vault given a well formed request"
-    (let [result (plugin/handle-request
-                   (mock-client-atom)
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= [{:key "identities#batman" :value "Bruce Wayne"}
-              {:key "identities#hulk" :value "Bruce Banner"}
-              {:key "identities#wonder-woman" :value "Diana Prince"}]
-             body))
-      (is (= 200 status))))
-  (testing "Can force override cache when configured to"
-    (let [client (mock-client-atom)
-          orig-result (plugin/handle-request
-                        client
-                        "go.cd.secrets.secrets-lookup"
-                        {:keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})]
-      (is (= [{:key "identities#batman" :value "Bruce Wayne"}
-              {:key "identities#hulk" :value "Bruce Banner"}
-              {:key "identities#wonder-woman" :value "Diana Prince"}]
-             (:response-body orig-result)))
-      (vault/write-secret! @client "identities" {:batman "Wayne, Bruce"
-                                                 :hulk "Banner, Bruce"
-                                                 :wonder-woman "Prince, Diana"})
-      (is (= [{:key "identities#batman" :value "Wayne, Bruce"}
-              {:key "identities#hulk" :value "Banner, Bruce"}
-              {:key "identities#wonder-woman" :value "Prince, Diana"}]
-             (:response-body
-               (plugin/handle-request
-                 client
-                 "go.cd.secrets.secrets-lookup"
-                 {:configuration {:force_read "true"}
-                  :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]}))))))
-  (testing "Fails cleanly when looking up secrets that don't exist"
-    (let [result (plugin/handle-request (mock-client-atom) "go.cd.secrets.secrets-lookup"
-                                        {:configuration {}
-                                         :keys          ["identities#dr-who" "identities#jack-the-ripper"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= {:message "Unable to resolve key(s) [\"identities#dr-who\" \"identities#jack-the-ripper\"]"}
-             body))
-      (is (= 404 status))))
-  (testing "Fails cleanly when other lookup error occurs"
-    (let [mock-client-that-errors (reify vault.core/SecretClient
-                                    (read-secret [_ _ _] (throw (ex-info "Mock Exception" {}))))
-          result (plugin/handle-request
-                   (atom mock-client-that-errors)
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["identities#batman"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= {:message "Error occurred during lookup of: [\"identities#batman\"]
+               body))
+        (is (= 500 status))))
+    (with-redefs [plugin/authenticate-client-from-inputs!
+                  (fn [_ _] nil)]
+      (testing "Results are returned as expected"
+        (let [result (plugin/handle-request
+                       "go.cd.secrets.secrets-lookup"
+                       {:configuration {}
+                        :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+                  {:key "identities#hulk" :value "Bruce Banner"}
+                  {:key "identities#wonder-woman" :value "Diana Prince"}]
+                 body))
+          (is (= 200 status))))
+      (testing "Can look up individual keys stored in vault given a well formed request"
+        (let [result (plugin/handle-request
+                       "go.cd.secrets.secrets-lookup"
+                       {:configuration {}
+                        :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+                  {:key "identities#hulk" :value "Bruce Banner"}
+                  {:key "identities#wonder-woman" :value "Diana Prince"}]
+                 body))
+          (is (= 200 status))))
+      (testing "Can force override cache when configured to"
+        (let [client (mock-client)]
+          (with-redefs [plugin/client-from-inputs
+                        (fn [_] client)]
+            (let [orig-result (plugin/handle-request
+                                "go.cd.secrets.secrets-lookup"
+                                {:keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]})]
+              (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+                      {:key "identities#hulk" :value "Bruce Banner"}
+                      {:key "identities#wonder-woman" :value "Diana Prince"}]
+                     (:response-body orig-result)))
+              (vault/write-secret! client "identities" {:batman "Wayne, Bruce"
+                                                        :hulk "Banner, Bruce"
+                                                        :wonder-woman "Prince, Diana"})
+              (is (= [{:key "identities#batman" :value "Wayne, Bruce"}
+                      {:key "identities#hulk" :value "Banner, Bruce"}
+                      {:key "identities#wonder-woman" :value "Prince, Diana"}]
+                     (:response-body
+                       (plugin/handle-request
+                         "go.cd.secrets.secrets-lookup"
+                         {:configuration {:force_read "true"}
+                          :keys          ["identities#batman" "identities#hulk" "identities#wonder-woman"]}))))))))
+      (testing "Fails cleanly when looking up secrets that don't exist"
+        (let [result (plugin/handle-request "go.cd.secrets.secrets-lookup"
+                                            {:configuration {}
+                                             :keys          ["identities#dr-who" "identities#jack-the-ripper"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= {:message "Unable to resolve key(s) [\"identities#dr-who\" \"identities#jack-the-ripper\"]"}
+                 body))
+          (is (= 404 status))))
+      (testing "Fails cleanly when other lookup error occurs"
+        (let [mock-client-that-errors (reify vault.core/SecretClient
+                                        (read-secret [_ _ _] (throw (ex-info "Mock Exception" {}))))]
+          (with-redefs [plugin/client-from-inputs
+                        (fn [_] mock-client-that-errors)]
+            (let [result (plugin/handle-request
+                           "go.cd.secrets.secrets-lookup"
+                           {:configuration {}
+                            :keys          ["identities#batman"]})
+                  body (:response-body result)
+                  status (:response-code result)]
+              (is (= {:message "Error occurred during lookup of: [\"identities#batman\"]
 clojure.lang.ExceptionInfo: Mock Exception {}"}
-             body))
-      (is (= 500 status))))
-  (testing "Can lookup token when specified without policies"
-    (let [result (plugin/handle-request
-                   (mock-client-atom)
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["TOKEN:"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= "TOKEN:" (:key (first body))))
-      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
-      (is (= 200 status))))
-  (testing "Can lookup token when specified with policies"
-    (let [result (plugin/handle-request
-                   (mock-client-atom)
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["TOKEN:1,2,3"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= "TOKEN:1,2,3" (:key (first body))))
-      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
-      (is (= 200 status))))
-  (testing "Can look up individual keys stored in vault given a well formed request"
-    (let [result (plugin/handle-request
-                   (mock-client-atom)
-                   "go.cd.secrets.secrets-lookup"
-                   {:configuration {}
-                    :keys          ["TOKEN:1,2" "TOKEN:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
-          body (:response-body result)
-          status (:response-code result)]
-      (is (= "TOKEN:1,2" (:key (first body))))
-      (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
-      (is (= "TOKEN:" (:key (second body))))
-      (is (and (string? (:value (second body))) (pos-int? (count (:value (second body))))))
-      (is (= [{:key "identities#batman" :value "Bruce Wayne"}
-              {:key "identities#hulk" :value "Bruce Banner"}
-              {:key "identities#wonder-woman" :value "Diana Prince"}]
-             (subvec body 2)))
-      (is (= 200 status)))))
+                     body))
+              (is (= 500 status))))))
+      (testing "Can lookup token when specified without policies"
+        (let [result (plugin/handle-request
+                       "go.cd.secrets.secrets-lookup"
+                       {:configuration {}
+                        :keys          ["TOKEN:"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= "TOKEN:" (:key (first body))))
+          (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+          (is (= 200 status))))
+      (testing "Can lookup token when specified with policies"
+        (let [result (plugin/handle-request
+                       "go.cd.secrets.secrets-lookup"
+                       {:configuration {}
+                        :keys          ["TOKEN:1,2,3"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= "TOKEN:1,2,3" (:key (first body))))
+          (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+          (is (= 200 status))))
+      (testing "Can look up individual keys stored in vault given a well formed request"
+        (let [result (plugin/handle-request
+                       "go.cd.secrets.secrets-lookup"
+                       {:configuration {}
+                        :keys          ["TOKEN:1,2" "TOKEN:" "identities#batman" "identities#hulk" "identities#wonder-woman"]})
+              body (:response-body result)
+              status (:response-code result)]
+          (is (= "TOKEN:1,2" (:key (first body))))
+          (is (and (string? (:value (first body))) (pos-int? (count (:value (first body))))))
+          (is (= "TOKEN:" (:key (second body))))
+          (is (and (string? (:value (second body))) (pos-int? (count (:value (second body))))))
+          (is (= [{:key "identities#batman" :value "Bruce Wayne"}
+                  {:key "identities#hulk" :value "Bruce Banner"}
+                  {:key "identities#wonder-woman" :value "Diana Prince"}]
+                 (subvec body 2)))
+          (is (= 200 status)))))))


### PR DESCRIPTION
As implemented, the VaultSecretsPlugin doesn't support multiple secret
configs. This causes secret lookups to use a client that is often
authenticated with incorrect credentials. This ensures a new, properly
configured client is used for each call to look up a set of secrets.