### PR TITLE
Allow configuring the STS signing region in IAM role mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 ## [Unreleased]
 ..
 
+## [0.4.0] - 2020-05-26
+- Add ability to configure STS signing region for AWS IAM auth method.
+  [#32](https://github.com/amperity/gocd-vault-secrets/pull/32)
+
 ## [0.3.3] - 2020-01-09
 - Fixed bug where plugin couldn't handle reading secrets from multiple configs.
   [#31](https://github.com/amperity/gocd-vault-secrets/pull/31)
@@ -35,7 +39,9 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 - Supports one Auth Method, direct Vault tokens
   [#4](https://github.com/amperity/gocd-vault-secrets/pull/4)
 
-[Unreleased]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/amperity/gocd-vault-secrets/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.3...v0.4.0
+[0.3.3]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/amperity/gocd-vault-secrets/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/amperity/gocd-vault-secrets/compare/v0.2.0...v0.3.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-vault-secrets "0.3.3"
+(defproject amperity/gocd-vault-secrets "0.4.0"
   :description "A plugin for GoCD providing secret material support via HashiCorp Vault."
   :url "https://github.com/amperity/gocd-vault-secrets"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
 
   :dependencies
   [[amperity/vault-clj "0.7.1"]
-   [amperity/vault-clj-aws "0.0.2"]
+   [amperity/vault-clj-aws "0.0.3"]
    [com.google.code.gson/gson "2.8.5"]
    [org.clojure/clojure "1.10.1"]]
 

--- a/resources/amperity/gocd/secret/vault/secrets-view.html
+++ b/resources/amperity/gocd/secret/vault/secrets-view.html
@@ -32,6 +32,12 @@
         <span class="iam_role" ng-show="GOINPUTNAME[iam_role].$error.server">{{GOINPUTNAME[iam_role].$error.server}}</span>
     </div>
 
+    <div class="form_item_mlock" ng-show="auth_method == 'aws-iam'">
+        <label>STS Signing Region</label>
+        <input type="text" ng-model="sts_region" ng-required="false" placeholder=""/>
+        <span class="sts_region" ng-show="GOINPUTNAME[sts_region].$error.server">{{GOINPUTNAME[sts_region].$error.server}}</span>
+    </div>
+
     <div class="form_item_block">
         <label>Secret Caching<span class='asterix'>*</span></label>
         <form>

--- a/src/amperity/gocd/secret/vault/plugin.clj
+++ b/src/amperity/gocd/secret/vault/plugin.clj
@@ -55,7 +55,11 @@
    ;; AWS Auth
    :iam_role {:metadata {:required false :secure false}
               :label "IAM Role"
-              :validate-fns []}})
+              :validate-fns []}
+
+   :sts_region {:metadata {:required false :secure false}
+                :label "STS Signing Region"
+                :validate-fns []}})
 
 ;; Signifies a token creation instead of a secret lookup
 (def signify-token-creation-str "TOKEN:")
@@ -171,6 +175,7 @@
       "aws-iam"
       (vault/authenticate! client :aws-iam
                            {:iam-role    (:iam_role inputs)
+                            :sts-region  (:sts_region inputs)
                             :credentials ^AWSCredentials (:aws_credentials inputs)})
 
       (throw (ex-info "Unhandled vault auth type"

--- a/test/amperity/gocd/secret/vault/plugin_test.clj
+++ b/test/amperity/gocd/secret/vault/plugin_test.clj
@@ -137,6 +137,7 @@
                      {:vault_addr      "https://amperity.com"
                       :auth_method     "aws-iam"
                       :iam_role        "role"
+                      :sts-region      "us-west-2"
                       :aws_credentials (aws/derive-credentials "hello" "goodbye" "7")
                       :force_read "false"})
             body (:response-body result)


### PR DESCRIPTION
To allow for authenticating against Vault using the IAM role method
where the backing Vault server has been configured with an explicit STS
region/endpoint (other than the default of us-east-1), we need to enable
configuring that in the plugin.

See also: https://github.com/amperity/vault-clj-aws/pull/2